### PR TITLE
Better complex type list editing + Mouse cursors

### DIFF
--- a/ImMilo/EditorPanel.cs
+++ b/ImMilo/EditorPanel.cs
@@ -535,8 +535,15 @@ public class EditorPanel
                         }
                         else
                         {
-                            var obj = constructor.Invoke([]);
-                            list?.Add(obj);
+                            try
+                            {
+                                var obj = constructor.Invoke([]);
+                                list?.Add(obj);
+                            }
+                            catch (Exception e)
+                            {
+                                Program.OpenErrorModal(e, "Cannot create new object in list");
+                            }
                         }
                     }
                 }

--- a/ImMilo/EditorPanel.cs
+++ b/ImMilo/EditorPanel.cs
@@ -488,8 +488,9 @@ public class EditorPanel
                 }
                 var collectionButtonSize = new Vector2(ImGui.GetFrameHeight(), ImGui.GetFrameHeight());
                 
+                
                 //ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, Vector2.Zero);
-                ImGui.BeginChild("values##" + field.GetHashCode(), new Vector2(0, 50),
+                ImGui.BeginChild("values##" + field.GetHashCode(), new Vector2(0, 125),
                     ImGuiChildFlags.Borders | ImGuiChildFlags.ResizeY);
                 var i = 0;
                 foreach (var value in collection)
@@ -547,7 +548,9 @@ public class EditorPanel
                         }
                     }
                 }
+
                 ImGui.EndChild();
+
                 //ImGui.PopStyleVar();
                 break;
             }

--- a/ImMilo/Program.cs
+++ b/ImMilo/Program.cs
@@ -76,6 +76,7 @@ public static partial class Program
     private static nint? MiloTexture;
 
     public static bool NoSettingsReload => viewingObject is Settings;
+    private static Dictionary<ImGuiMouseCursor, SDL_Cursor> cursorCache = new();
 
     static void Main(string[] args)
     {
@@ -261,6 +262,7 @@ public static partial class Program
         DrawErrorModal();
         UIContent();
         ProcessPrompts();
+        
         ImGui.End();
         ImGui.PopStyleVar();
         ImGui.PopStyleVar();
@@ -269,6 +271,27 @@ public static partial class Program
             ImGui.ShowDemoWindow();
         }
         DrawAboutWindow();
+        UpdateMouseCursor();
+    }
+
+    private static void UpdateMouseCursor()
+    {
+        var cursor = ImGui.GetMouseCursor();
+        if (!cursorCache.TryGetValue(cursor, out var sdlCursor))
+        {
+            sdlCursor = cursor switch
+            {
+                ImGuiMouseCursor.Hand => Sdl2Native.SDL_CreateSystemCursor(SDL_SystemCursor.Hand),
+                ImGuiMouseCursor.ResizeAll => Sdl2Native.SDL_CreateSystemCursor(SDL_SystemCursor.SizeAll),
+                ImGuiMouseCursor.TextInput => Sdl2Native.SDL_CreateSystemCursor(SDL_SystemCursor.IBeam),
+                ImGuiMouseCursor.ResizeNS => Sdl2Native.SDL_CreateSystemCursor(SDL_SystemCursor.SizeNS),
+                ImGuiMouseCursor.ResizeEW => Sdl2Native.SDL_CreateSystemCursor(SDL_SystemCursor.SizeWE),
+                ImGuiMouseCursor.NotAllowed => Sdl2Native.SDL_CreateSystemCursor(SDL_SystemCursor.No),
+                _ => Sdl2Native.SDL_CreateSystemCursor(SDL_SystemCursor.Arrow)
+            };
+            cursorCache[cursor] = sdlCursor;
+        }
+        Sdl2Native.SDL_SetCursor(sdlCursor);
     }
 
     public static void OpenErrorModal(Exception e, string message)


### PR DESCRIPTION
Improves the editor for lists of complex types, allowing for removing and adding (provided the object has a parameterless constructor). Also shows the list type and length.
![image](https://github.com/user-attachments/assets/4a9be140-645f-433a-9dd8-5e893d962ee8)
In addition, resize cursors and text input cursors will now show.
![image](https://github.com/user-attachments/assets/2624a414-8281-401b-b13c-8b5ace86c7b6)
Todo: Reordering complex lists.